### PR TITLE
Add styling for tabs

### DIFF
--- a/the-matrix-theme.el
+++ b/the-matrix-theme.el
@@ -483,7 +483,19 @@
    `(elfeed-log-debug-level-face ((t (:foreground ,color-blue))))
    `(elfeed-log-error-level-face ((t (:inherit error))))
    `(elfeed-log-info-level-face ((t (:foreground ,color-blue))))
-   `(elfeed-log-warn-level-face ((t (:inherit warning))))))
+   `(elfeed-log-warn-level-face ((t (:inherit warning))))
+
+   ;; tab-line/tab-bar (Emacs 27+)
+   `(tab-line ((t (:background ,color-bg-alt :foreground ,color-fg))))
+   `(tab-line-tab ((t (:background ,color-bg :foreground ,color-fg))))
+   `(tab-line-tab-inactive ((t (:inherit tab-line-tab :background ,color-bg-alt :foreground ,color-fg))))
+   `(tab-line-tab-inactive-alternate ((t (:inherit tab-line-tab-inactive))))
+   `(tab-line-tab-current ((t (:background ,color-bg :foreground ,color-fg))))
+   `(tab-line-highlight ((t (:inherit tab-line-tab))))
+   `(tab-line-close-highlight ((t (:foreground color-hl))))
+   `(tab-bar ((t (:background ,color-bg-alt :foreground ,color-fg))))
+   `(tab-bar-tab ((t (:background ,color-bg :foreground ,color-fg))))
+   `(tab-bar-tab-inactive ((t (:inherit tab-line-tab :background ,color-bg-alt :foreground ,color-fg))))))
 
 ;;;###autoload
 (when load-file-name


### PR DESCRIPTION
Here is how tabs look. The active tab has a black background, the inactive ones a slightly lighter one.

![Screenshot from 2022-01-05 11-25-29](https://user-images.githubusercontent.com/20991/148202465-f8ca8bd3-a27f-44ca-8143-7dc84a6374e8.png)
